### PR TITLE
[BUGFIX][DEV-1575] Migrate deprecated `set-output` to env files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,16 +38,23 @@ jobs:
           extensions: mbstring, xml, ctype, iconv
           coverage: none
 
-      - name: Cache composer dependencies
-        uses: actions/cache@v3
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
         with:
-          path: vendor
-          key: ${{ matrix.php }}-composer-${{ matrix.symfony }}
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
 
       - name: Install
         run: |
           sed -ri 's/"symfony\/(.+)": "(.+)"/"symfony\/\1": "'${{ matrix.symfony }}'"/' composer.json;
-          composer update --prefer-dist --no-progress
+          composer update --prefer-dist --no-progress --ansi
           composer info
           git checkout composer.json
 


### PR DESCRIPTION
GitHub started to deprecate `set-output` in favor of environment
files due to security reasons. See [1] for further information.

[1] https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
