### PR TITLE
[!!!][TASK] Update default realm URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ php bin/console debug:config t3g_keycloak
 # Default configuration for extension with alias: "t3g_keycloak"
 t3g_keycloak:
     keycloak:
-        jku_url: 'https://login.typo3.com/auth/realms/TYPO3/protocol/openid-connect/certs'
+        jku_url: 'https://login.typo3.com/realms/TYPO3/protocol/openid-connect/certs'
         user_provider_class: T3G\Bundle\Keycloak\Security\KeyCloakUserProvider
         default_roles:
             # Defaults:

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -24,7 +24,7 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('keycloak')->addDefaultsIfNotSet()
                     ->children()
                         ->scalarNode('jku_url')
-                            ->defaultValue('https://login.typo3.com/auth/realms/TYPO3/protocol/openid-connect/certs')
+                            ->defaultValue('https://login.typo3.com/realms/TYPO3/protocol/openid-connect/certs')
                             ->cannotBeEmpty()
                         ->end()
                         ->scalarNode('user_provider_class')


### PR DESCRIPTION
With the update to Keycloak 17+, the `/auth/` substring was removed from realm URLs. To reflect this change, the default `jku_url` is updated.