### PR TITLE
[BUGFIX] Invalidate Symfony session when Keycloak session expired

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,5 +100,5 @@ t3g_keycloak:
         # redirect_route passed to keycloak
         authentication: t3g_keycloak_oauthCallback
         # route of the Symfony logout handling
-        logout_route: logout
+        logout_route: _logout_main
 ```

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -51,7 +51,7 @@ class Configuration implements ConfigurationInterface
                             ->defaultValue('home')
                         ->end()
                         ->scalarNode('logout_route')
-                            ->defaultValue('logout')
+                            ->defaultValue('_logout_main')
                         ->end()
                 ->end()
             ->end()

--- a/src/EventSubscriber/RequestSubscriber.php
+++ b/src/EventSubscriber/RequestSubscriber.php
@@ -14,8 +14,6 @@ use KnpU\OAuth2ClientBundle\Client\OAuth2ClientInterface;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Token\AccessToken;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\Routing\RouterInterface;
 use T3G\Bundle\Keycloak\Security\KeyCloakAuthenticator;
@@ -62,12 +60,8 @@ class RequestSubscriber implements EventSubscriberInterface
                 }
 
                 if ('invalid_grant' === $body['error']) {
-                    // User had a keycloak session, but refreshing the access token failed. Enforce logout.
-                    $response = new RedirectResponse(
-                        $this->router->generate('logout'),
-                        Response::HTTP_TEMPORARY_REDIRECT
-                    );
-                    $event->setResponse($response);
+                    // User had a keycloak session, but refreshing the access token failed. Enforce logout in Symfony.
+                    $session->invalidate();
                     return;
                 }
 


### PR DESCRIPTION
When the Keycloak session has expired, we're now invalidation the current Symfony session to avoid redirect loops caused by diverged states between Symfony and Keycloak.