### PR TITLE
[TASK] Remove coveralls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,11 +64,3 @@ jobs:
           php -dpcov.enabled=1 -dpcov.directory="." -dxdebug.mode="coverage" ./vendor/bin/phpunit -c build/phpunit.xml.dist --log-junit var/log/junit/phpunit.junit.xml --coverage-clover var/log/junit/coverage.xml --coverage-xml var/log/junit/coverage-xml/
         env:
           COMPOSER_PROCESS_TIMEOUT: 1200
-
-      - name: Upload coverage results to Coveralls
-        continue-on-error: true
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          composer global require php-coveralls/php-coveralls --no-progress --no-suggest --no-interaction
-          /home/runner/.composer/vendor/bin/php-coveralls -c build/.coveralls.yml -vvv --json_path=var/log/coveralls-upload.json

--- a/build/.coveralls.yml
+++ b/build/.coveralls.yml
@@ -1,1 +1,0 @@
-coverage_clover: var/log/junit/coverage.xml


### PR DESCRIPTION
Coveralls became quite expensive and is not actively used. The integration is removed and will be replaced with something different, once an suitable alternative pops up.